### PR TITLE
fix(core): restore box component if it has been deleted

### DIFF
--- a/widget-src/_shared/constants.ts
+++ b/widget-src/_shared/constants.ts
@@ -17,3 +17,7 @@ export const defaultBoxVariants: GetVariantsParams = [
     variants: { none: 0, XS: 1, L: 10 },
   },
 ];
+
+export enum ComponentNames {
+  Box = "BOX",
+}

--- a/widget-src/_shared/utils/deleteSlice.test.ts
+++ b/widget-src/_shared/utils/deleteSlice.test.ts
@@ -1,0 +1,85 @@
+import {
+  mockGetNodeById,
+  mockNotify,
+  mockRootFindOne,
+} from "../../../__mocks__/figmaMock";
+import { deleteSlice } from "./deleteSlice";
+import * as RestoreBoxComponent from "./restoreBoxComponent";
+
+const mockRestoreBoxComponent = jest.fn();
+const mockDelete = jest.fn();
+const mockRemove = jest.fn();
+jest
+  .spyOn(RestoreBoxComponent, "restoreBoxComponent")
+  .mockImplementation(mockRestoreBoxComponent);
+
+describe("deleteSlice", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should call notify and do nothing else if the state is empty", () => {
+    deleteSlice("any id", {
+      delete: mockDelete,
+      size: 0,
+    } as unknown as SyncedMap);
+
+    expect(mockDelete).not.toBeCalled();
+    expect(mockNotify).toBeCalledTimes(1);
+  });
+
+  it("should delete the slice and related instances if the box is found", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({ remove: mockRemove });
+
+    deleteSlice("any id", {
+      delete: mockDelete,
+      size: 1,
+      get: () => ({ refIds: ["instance id 1", "instance id 2"] }),
+    } as unknown as SyncedMap);
+
+    expect(mockNotify).not.toBeCalled();
+    expect(mockDelete).toBeCalledTimes(1);
+    expect(mockRemove).toBeCalledTimes(2);
+  });
+
+  it("should not call remove if refIds is an empty array", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({ remove: mockRemove });
+
+    deleteSlice("any id", {
+      delete: mockDelete,
+      size: 1,
+      get: () => undefined,
+    } as unknown as SyncedMap);
+
+    expect(mockRemove).not.toBeCalled();
+  });
+
+  it("should not call remove if getNodeById returns undefined", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue(undefined);
+
+    deleteSlice("any id", {
+      delete: mockDelete,
+      size: 1,
+      get: () => ({ refIds: ["1", "2"] }),
+    } as unknown as SyncedMap);
+
+    expect(mockRemove).not.toBeCalled();
+  });
+
+  it("should call restoreBoxComponent if box component is not found", () => {
+    mockRootFindOne.mockReturnValue(null);
+    mockGetNodeById.mockReturnValue({ remove: mockRemove });
+
+    deleteSlice("any id", {
+      delete: mockDelete,
+      size: 1,
+      get: () => ({ refIds: ["instance id 1", "instance id 2"] }),
+    } as unknown as SyncedMap);
+
+    expect(mockNotify).not.toBeCalled();
+    expect(mockDelete).toBeCalledTimes(1);
+    expect(mockRestoreBoxComponent).toBeCalledTimes(1);
+  });
+});

--- a/widget-src/_shared/utils/deleteSlice.ts
+++ b/widget-src/_shared/utils/deleteSlice.ts
@@ -1,0 +1,29 @@
+import { ComponentNames } from "../constants";
+import { SliceItem } from "../types";
+import { restoreBoxComponent } from "./restoreBoxComponent";
+
+export const deleteSlice = (id: string, map: SyncedMap<SliceItem>) => {
+  if (map.size < 1) {
+    figma.notify("Impossible to remove all slices. Please keep at least one", {
+      error: true,
+      timeout: 3000,
+    });
+    return;
+  }
+
+  const boxComponent = figma.root.findOne(
+    (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
+  );
+
+  const refIds = map.get(id)?.refIds || [];
+  map.delete(id);
+
+  if (boxComponent) {
+    refIds.map((refId) => {
+      figma.getNodeById(refId)?.remove();
+    });
+    return;
+  }
+
+  restoreBoxComponent(map);
+};

--- a/widget-src/_shared/utils/editSliceName.test.ts
+++ b/widget-src/_shared/utils/editSliceName.test.ts
@@ -1,0 +1,130 @@
+import { mockGetNodeById, mockRootFindOne } from "../../../__mocks__/figmaMock";
+import { BoxPropertyName } from "../constants";
+import { editSliceName } from "./editSliceName";
+import * as Utils from "./utils";
+import * as RestoreBoxComponent from "./restoreBoxComponent";
+
+const mockUpdateVariantName = jest.fn();
+jest
+  .spyOn(Utils, "updateVariantName")
+  .mockImplementation(mockUpdateVariantName);
+
+const mockSet = jest.fn();
+const mockRestoreBoxComponent = jest.fn();
+jest
+  .spyOn(RestoreBoxComponent, "restoreBoxComponent")
+  .mockImplementation(mockRestoreBoxComponent);
+
+describe("editSliceName", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should change the name of a slice on the state and on related box instances", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({ type: "COMPONENT", name: "oldName" });
+
+    editSliceName({
+      e: { characters: "newName" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "oldName",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "newName",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).toBeCalledWith("instance1");
+    expect(mockGetNodeById).toBeCalledWith("instance2");
+    expect(mockUpdateVariantName).toBeCalledWith({
+      instanceName: "oldName",
+      newVariantName: "newName",
+      propertyName: BoxPropertyName.Radius,
+    });
+  });
+  it("should not change the name if e.characters is empty string", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({ type: "COMPONENT", name: "oldName" });
+
+    editSliceName({
+      e: { characters: "" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "oldName",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "oldName",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).toBeCalledWith("instance1");
+    expect(mockGetNodeById).toBeCalledWith("instance2");
+    expect(mockUpdateVariantName).toBeCalledWith({
+      instanceName: "oldName",
+      newVariantName: "oldName",
+      propertyName: BoxPropertyName.Radius,
+    });
+  });
+  it("should not call updateVariantName if getNodeById does not return anything", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue(null);
+
+    editSliceName({
+      e: { characters: "" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "oldName",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "oldName",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).toBeCalledWith("instance1");
+    expect(mockGetNodeById).toBeCalledWith("instance2");
+    expect(mockUpdateVariantName).not.toBeCalled();
+  });
+  it("should call restoreBoxComponent if BOX is not found", () => {
+    mockRootFindOne.mockReturnValue(null);
+    mockGetNodeById.mockReturnValue({ type: "COMPONENT", name: "oldName" });
+
+    editSliceName({
+      e: { characters: "" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "oldName",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "oldName",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).not.toBeCalled();
+    expect(mockUpdateVariantName).not.toBeCalled();
+    expect(mockRestoreBoxComponent).toBeCalledTimes(1);
+  });
+});

--- a/widget-src/_shared/utils/editSliceName.ts
+++ b/widget-src/_shared/utils/editSliceName.ts
@@ -1,0 +1,36 @@
+import { ComponentNames, BoxPropertyName } from "../constants";
+import { SliceItem } from "../types";
+import { restoreBoxComponent } from "./restoreBoxComponent";
+import { updateVariantName } from "./utils";
+
+export const editSliceName = (params: {
+  slice: SliceItem;
+  e: TextEditEvent;
+  map: SyncedMap<SliceItem>;
+}) => {
+  const { e, map, slice } = params;
+  const newName = e.characters || slice.name;
+  map.set(slice.id, {
+    ...slice,
+    name: newName,
+  });
+
+  const boxComponent = figma.root.findOne(
+    (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
+  );
+
+  if (boxComponent) {
+    slice.refIds.forEach((refId) => {
+      const variant = figma.getNodeById(refId);
+      if (variant) {
+        variant.name = updateVariantName({
+          instanceName: variant.name,
+          newVariantName: newName,
+          propertyName: BoxPropertyName.Radius,
+        });
+      }
+    });
+    return;
+  }
+  restoreBoxComponent(map);
+};

--- a/widget-src/_shared/utils/editSliceValue.test.ts
+++ b/widget-src/_shared/utils/editSliceValue.test.ts
@@ -1,0 +1,126 @@
+import { mockGetNodeById, mockRootFindOne } from "../../../__mocks__/figmaMock";
+import { editSliceValue } from "./editSliceValue";
+import * as RestoreBoxComponent from "./restoreBoxComponent";
+
+const mockSet = jest.fn();
+const mockRestoreBoxComponent = jest.fn();
+jest
+  .spyOn(RestoreBoxComponent, "restoreBoxComponent")
+  .mockImplementation(mockRestoreBoxComponent);
+
+describe("editSliceValue", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should change the value of a slice on the state and on related box instances", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({
+      type: "COMPONENT",
+      name: "name",
+      value: 0,
+    });
+
+    editSliceValue({
+      e: { characters: "1" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "name",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+      styleKey: "cornerRadius",
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "name",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).toBeCalledWith("instance1");
+    expect(mockGetNodeById).toBeCalledWith("instance2");
+  });
+  it("should not change the value if e.characters is not a valid number", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue({
+      type: "COMPONENT",
+      name: "name",
+      value: 1,
+    });
+
+    editSliceValue({
+      e: { characters: "any non-number string" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "name",
+        refIds: ["instance1", "instance2"],
+        value: 1,
+      },
+      styleKey: "cornerRadius",
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "name",
+      refIds: ["instance1", "instance2"],
+      value: 1,
+    });
+    expect(mockGetNodeById).toBeCalledWith("instance1");
+    expect(mockGetNodeById).toBeCalledWith("instance2");
+  });
+  it("should call restoreBoxComponent if BOX is not found", () => {
+    mockRootFindOne.mockReturnValue(null);
+    mockGetNodeById.mockReturnValue({
+      type: "COMPONENT",
+      name: "name",
+      value: 1,
+    });
+
+    editSliceValue({
+      e: { characters: "2" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "name",
+        refIds: ["instance1", "instance2"],
+        value: 2,
+      },
+      styleKey: "cornerRadius",
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "name",
+      refIds: ["instance1", "instance2"],
+      value: 2,
+    });
+    expect(mockGetNodeById).not.toBeCalled();
+    expect(mockRestoreBoxComponent).toBeCalledTimes(1);
+  });
+  it("should not crash if getNodeById returns null", () => {
+    mockRootFindOne.mockReturnValue({});
+    mockGetNodeById.mockReturnValue(null);
+
+    editSliceValue({
+      e: { characters: "2" },
+      map: { set: mockSet } as unknown as SyncedMap,
+      slice: {
+        id: "1",
+        name: "name",
+        refIds: ["instance1", "instance2"],
+        value: 2,
+      },
+      styleKey: "cornerRadius",
+    });
+
+    expect(mockSet).toBeCalledWith("1", {
+      id: "1",
+      name: "name",
+      refIds: ["instance1", "instance2"],
+      value: 2,
+    });
+    expect(mockGetNodeById).toBeCalledTimes(2);
+  });
+});

--- a/widget-src/_shared/utils/editSliceValue.ts
+++ b/widget-src/_shared/utils/editSliceValue.ts
@@ -1,0 +1,32 @@
+import { ComponentNames } from "../constants";
+import { SliceItem, BoxStyleKeys } from "../types";
+import { restoreBoxComponent } from "./restoreBoxComponent";
+
+export const editSliceValue = (params: {
+  slice: SliceItem;
+  e: TextEditEvent;
+  map: SyncedMap<SliceItem>;
+  styleKey: BoxStyleKeys;
+}) => {
+  const { e, map, slice, styleKey } = params;
+  const newValue = Number(e.characters) || slice.value;
+  map.set(slice.id, {
+    ...slice,
+    value: newValue,
+  });
+
+  const boxComponent = figma.root.findOne(
+    (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
+  );
+
+  if (boxComponent) {
+    slice.refIds.forEach((refId) => {
+      const variant = figma.getNodeById(refId);
+      if (variant?.type === "COMPONENT") {
+        variant[styleKey] = newValue;
+      }
+    });
+    return;
+  }
+  restoreBoxComponent(map);
+};

--- a/widget-src/_shared/utils/getCurrentBoxVariants.test.ts
+++ b/widget-src/_shared/utils/getCurrentBoxVariants.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentBoxVariants } from "./getCurrentBoxVariants";
 
 describe("initTheme", () => {
-  it("should return expected output", () => {
+  it("should return expected box variants", () => {
     const input = [
       {
         type: "COMPONENT",
@@ -42,6 +42,46 @@ describe("initTheme", () => {
         { id: expect.any(String), name: "A", value: 2, refIds: ["1", "3"] },
         { id: expect.any(String), name: "B", value: 4, refIds: ["2", "4"] },
       ],
+    });
+  });
+  it("should ignore every object which is not a COMPONENT", () => {
+    const input = [
+      {
+        type: "COMPONENT",
+        id: "1",
+        name: "Radius=XS",
+        cornerRadius: 1,
+        strokeWeight: 2,
+      },
+      {
+        type: "RECTANGLE",
+        id: "2",
+        name: "Any name",
+        cornerRadius: 1,
+        strokeWeight: 4,
+      },
+    ] as SceneNode[];
+
+    expect(getCurrentBoxVariants(input)).toEqual({
+      Radius: [{ id: expect.any(String), name: "XS", value: 1, refIds: ["1"] }],
+      "Border width": expect.any(Array),
+    });
+  });
+
+  it("should set 0 as value if either cornerRadius or strokeWeight is figma.mixed", () => {
+    const input = [
+      {
+        type: "COMPONENT",
+        id: "1",
+        name: "Radius=XS",
+        cornerRadius: figma.mixed,
+        strokeWeight: figma.mixed,
+      },
+    ] as SceneNode[];
+
+    expect(getCurrentBoxVariants(input)).toEqual({
+      Radius: [{ id: expect.any(String), name: "XS", value: 0, refIds: ["1"] }],
+      "Border width": expect.any(Array),
     });
   });
 });

--- a/widget-src/_shared/utils/getVariantCombinations.test.ts
+++ b/widget-src/_shared/utils/getVariantCombinations.test.ts
@@ -1,0 +1,95 @@
+import { BoxPropertyName } from "../constants";
+import { getVariantCombinations } from "./getVariantCombinations";
+
+describe("get variant combinations", () => {
+  it("should return expected combinations", () => {
+    const res = getVariantCombinations([
+      { propertyName: BoxPropertyName.Radius, variants: { S: 1, M: 2, L: 3 } },
+      { propertyName: BoxPropertyName.BorderWidth, variants: { X: 1, Y: 2 } },
+    ]);
+
+    expect(res).toEqual([
+      {
+        name: "Radius=S, Border width=X",
+        cornerRadius: 1,
+        strokeWeight: 1,
+      },
+      {
+        name: "Radius=S, Border width=Y",
+        cornerRadius: 1,
+        strokeWeight: 2,
+      },
+      {
+        name: "Radius=M, Border width=X",
+        cornerRadius: 2,
+        strokeWeight: 1,
+      },
+      {
+        name: "Radius=M, Border width=Y",
+        cornerRadius: 2,
+        strokeWeight: 2,
+      },
+      {
+        name: "Radius=L, Border width=X",
+        cornerRadius: 3,
+        strokeWeight: 1,
+      },
+      {
+        name: "Radius=L, Border width=Y",
+        cornerRadius: 3,
+        strokeWeight: 2,
+      },
+    ]);
+  });
+
+  it("should be possible to add a variant", () => {
+    const res1 = getVariantCombinations([
+      { propertyName: BoxPropertyName.Radius, variants: { XL: 10 } },
+      { propertyName: BoxPropertyName.BorderWidth, variants: { X: 1, Y: 2 } },
+    ]);
+
+    const res2 = getVariantCombinations([
+      {
+        propertyName: BoxPropertyName.Radius,
+        variants: { S: 1, M: 2, L: 3, XL: 10 },
+      },
+      { propertyName: BoxPropertyName.BorderWidth, variants: { Z: 4 } },
+    ]);
+
+    const result = [...res1, ...res2];
+
+    expect(result).toEqual([
+      expect.objectContaining({
+        name: "Radius=XL, Border width=X",
+        cornerRadius: 10,
+        strokeWeight: 1,
+      }),
+      expect.objectContaining({
+        name: "Radius=XL, Border width=Y",
+        cornerRadius: 10,
+        strokeWeight: 2,
+      }),
+
+      expect.objectContaining({
+        name: "Radius=S, Border width=Z",
+        cornerRadius: 1,
+        strokeWeight: 4,
+      }),
+      expect.objectContaining({
+        name: "Radius=M, Border width=Z",
+        cornerRadius: 2,
+        strokeWeight: 4,
+      }),
+      expect.objectContaining({
+        name: "Radius=L, Border width=Z",
+        cornerRadius: 3,
+        strokeWeight: 4,
+      }),
+      expect.objectContaining({
+        name: "Radius=XL, Border width=Z",
+        cornerRadius: 10,
+        strokeWeight: 4,
+      }),
+    ]);
+  });
+});

--- a/widget-src/_shared/utils/restoreBoxComponent.ts
+++ b/widget-src/_shared/utils/restoreBoxComponent.ts
@@ -1,0 +1,38 @@
+import { BoxPropertyName, ComponentNames } from "../constants";
+import { SliceItem } from "../types";
+import { createBoxInstances } from "./createBoxInstances";
+import { getBoxVariantsFromState } from "./getBoxVariantsFromState";
+import { getVariantCombinations } from "./getVariantCombinations";
+
+/**
+ *
+ * It create a new box component, and override the state
+ * using new instances created
+ *
+ * @param radiiMap the radii state map
+ * @param additionalItem optional item to add to existing
+ */
+
+export const restoreBoxComponent = (
+  radiiMap: SyncedMap<SliceItem>,
+  additionalItem?: SliceItem
+) => {
+  const currentValues = radiiMap.values();
+  const state = additionalItem
+    ? [...currentValues, additionalItem]
+    : currentValues;
+
+  const getVariantsParams = getBoxVariantsFromState(state);
+  const boxVariants = getVariantCombinations(getVariantsParams);
+  const { instances, sliceItems } = createBoxInstances(boxVariants);
+
+  const radiiSliceItems = sliceItems[BoxPropertyName.Radius];
+  const box = figma.combineAsVariants(instances, figma.currentPage);
+
+  box.name = ComponentNames.Box;
+
+  // reset the state
+  radiiMap.keys().forEach((key) => radiiMap.delete(key));
+  // save the updated state
+  radiiSliceItems.forEach((sliceItem) => radiiMap.set(sliceItem.id, sliceItem));
+};

--- a/widget-src/_shared/utils/utils.test.ts
+++ b/widget-src/_shared/utils/utils.test.ts
@@ -1,0 +1,12 @@
+import { updateVariantName } from "./utils";
+
+describe("updateVariantName", () => {
+  it("should return a new name with the variantName replaced for the selected propertyName", () => {
+    const newName = updateVariantName({
+      instanceName: "Radius=S, Border width=A",
+      newVariantName: "X",
+      propertyName: "Radius",
+    });
+    expect(newName).toBe("Radius=X, Border width=A");
+  });
+});

--- a/widget-src/_shared/utils/utils.ts
+++ b/widget-src/_shared/utils/utils.ts
@@ -1,73 +1,14 @@
-import { SliceItem } from "../types";
-
 export const updateVariantName = ({
   instanceName,
   newVariantName,
-  sliceName,
+  propertyName,
 }: {
   instanceName: string;
   newVariantName: string;
-  sliceName: string;
+  propertyName: string;
 }) => {
-  const regex = new RegExp(`${sliceName}=[^,]+`, "i");
-  const newSlice = `${sliceName}=${newVariantName}`;
+  const regex = new RegExp(`${propertyName}=[^,]+`, "i");
+  const newSlice = `${propertyName}=${newVariantName}`;
   const updatedName = instanceName.slice().replace(regex, newSlice);
   return updatedName;
-};
-
-export const deleteSlice = (id: string, map: SyncedMap<SliceItem>) => {
-  if (map.size > 1) {
-    const refIds = map.get(id)?.refIds || [];
-    map.delete(id);
-    refIds.map((refId) => {
-      figma.getNodeById(refId)?.remove();
-    });
-    return;
-  }
-
-  figma.notify("Impossible to remove all slices. Please keep at least one", {
-    error: true,
-    timeout: 3000,
-  });
-};
-
-export const editSliceName = (params: {
-  slice: SliceItem;
-  e: TextEditEvent;
-  map: SyncedMap<SliceItem>;
-}) => {
-  const { e, map, slice } = params;
-  map.set(slice.id, {
-    ...slice,
-    name: e.characters || slice.name,
-  });
-  slice.refIds.map((refId) => {
-    const variant = figma.getNodeById(refId);
-    if (variant?.type === "COMPONENT") {
-      variant.name = updateVariantName({
-        instanceName: variant.name,
-        newVariantName: e.characters,
-        sliceName: "Radius",
-      });
-    }
-  });
-};
-
-export const editSliceValue = (params: {
-  slice: SliceItem;
-  e: TextEditEvent;
-  map: SyncedMap<SliceItem>;
-}) => {
-  const { e, map, slice } = params;
-  const newValue = Number(e.characters) || slice.value;
-  map.set(slice.id, {
-    ...slice,
-    value: newValue,
-  });
-  slice.refIds.map((refId) => {
-    const variant = figma.getNodeById(refId);
-    if (variant?.type === "COMPONENT") {
-      variant.cornerRadius = newValue;
-    }
-  });
 };

--- a/widget-src/components/Radii/RadiiSlice.tsx
+++ b/widget-src/components/Radii/RadiiSlice.tsx
@@ -1,9 +1,7 @@
 import { SliceItem } from "../../_shared/types";
-import {
-  deleteSlice,
-  editSliceName,
-  editSliceValue,
-} from "../../_shared/utils/utils";
+import { deleteSlice } from "../../_shared/utils/deleteSlice";
+import { editSliceName } from "../../_shared/utils/editSliceName";
+import { editSliceValue } from "../../_shared/utils/editSliceValue";
 import { DeleteButton } from "../Buttons/DeleteButton";
 
 const { widget } = figma;
@@ -65,7 +63,14 @@ export const RadiiSlice = ({ radiiMap, ...slice }: Props) => {
           fontWeight={500}
           strokeWidth={0.632}
           value={`${slice.value}`}
-          onTextEditEnd={(e) => editSliceValue({ e, map: radiiMap, slice })}
+          onTextEditEnd={(e) =>
+            editSliceValue({
+              e,
+              map: radiiMap,
+              slice,
+              styleKey: "cornerRadius",
+            })
+          }
         />
       </AutoLayout>
     </AutoLayout>

--- a/widget-src/components/Radii/RadiiSlices.tsx
+++ b/widget-src/components/Radii/RadiiSlices.tsx
@@ -1,31 +1,13 @@
 import { SliceItem } from "../../_shared/types";
 import { AddButton } from "../Buttons/AddButton";
 import { RadiiSlice } from "./RadiiSlice";
+import { addRadiiSlice } from "./utils";
 
 const { widget } = figma;
 const { Text, Frame, AutoLayout } = widget;
 
 type Props = {
   radiiMap: SyncedMap<SliceItem>;
-};
-
-export const addRadiiSlice = (radiiMap: SyncedMap<SliceItem>) => {
-  const newVariant = figma.createComponent();
-  newVariant.name = "Radius=N";
-  newVariant.cornerRadius = 0;
-  newVariant.fills = [{ type: "SOLID", color: { r: 0, g: 0, b: 0 } }];
-  radiiMap.set(newVariant.id, {
-    id: newVariant.id,
-    name: "N",
-    value: 0,
-    refIds: [newVariant.id],
-  });
-  const boxComponent = figma.root.findOne(
-    (node) => node.type === "COMPONENT_SET" && node.name === "BOX"
-  );
-  if (boxComponent?.type === "COMPONENT_SET") {
-    boxComponent.appendChild(newVariant);
-  }
 };
 
 export const RadiiSlices = ({ radiiMap }: Props) => {

--- a/widget-src/components/Radii/utils.test.ts
+++ b/widget-src/components/Radii/utils.test.ts
@@ -1,0 +1,68 @@
+import {
+  mockCombineAsVariants,
+  mockRootFindOne,
+} from "../../../__mocks__/figmaMock";
+import { ComponentNames } from "../../_shared/constants";
+import { SliceItem } from "../../_shared/types";
+import { addRadiiSlice } from "./utils";
+
+describe("addRadiiSlice", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+  it("should add new sliceItems on the state and append new instances to the box", () => {
+    const mockSet = jest.fn();
+    const mockAppendChild = jest.fn();
+    mockRootFindOne.mockReturnValue({
+      type: "COMPONENT_SET",
+      name: ComponentNames.Box,
+      appendChild: mockAppendChild,
+    });
+    addRadiiSlice({ set: mockSet } as unknown as SyncedMap<SliceItem>);
+
+    expect(mockSet).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "N",
+      value: 0,
+      refIds: [expect.any(String)],
+    } as SliceItem);
+    expect(mockSet).toBeCalledTimes(1);
+
+    expect(mockAppendChild).toBeCalledWith(
+      expect.objectContaining({ name: "Radius=N", cornerRadius: 0 })
+    );
+    expect(mockAppendChild).toBeCalledTimes(1);
+  });
+
+  it("should create a new box component and restore the state with the new instances if BOX is not found", () => {
+    const mockSet = jest.fn();
+    const mockAppendChild = jest.fn();
+    const mockMapDelete = jest.fn();
+    mockRootFindOne.mockReturnValue(null);
+    addRadiiSlice({
+      set: mockSet,
+      values: () => [{ id: "1", name: "S", refIds: ["222"], value: 1 }],
+      keys: () => ["1"],
+      delete: mockMapDelete,
+    } as unknown as SyncedMap<SliceItem>);
+
+    expect(mockAppendChild).not.toBeCalled();
+    expect(mockCombineAsVariants).toBeCalledTimes(1);
+
+    // reset state
+    expect(mockMapDelete).toBeCalledTimes(1);
+    // set up new state (updated sliceItems + new one)
+    expect(mockSet).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "N",
+      value: 0,
+      refIds: [expect.any(String)],
+    } as SliceItem);
+    expect(mockSet).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "S",
+      value: 1,
+      refIds: [expect.any(String)],
+    } as SliceItem);
+  });
+});

--- a/widget-src/components/Radii/utils.ts
+++ b/widget-src/components/Radii/utils.ts
@@ -1,0 +1,27 @@
+import { BoxPropertyName, ComponentNames } from "../../_shared/constants";
+import { SliceItem } from "../../_shared/types";
+import { createBoxInstances } from "../../_shared/utils/createBoxInstances";
+import { getVariantCombinations } from "../../_shared/utils/getVariantCombinations";
+import { restoreBoxComponent } from "../../_shared/utils/restoreBoxComponent";
+
+export const addRadiiSlice = (radiiMap: SyncedMap<SliceItem>) => {
+  const boxComponent = figma.root.findOne(
+    (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
+  );
+  if (boxComponent?.type === "COMPONENT_SET") {
+    const boxVariants = getVariantCombinations([
+      { propertyName: BoxPropertyName.Radius, variants: { N: 0 } },
+    ]);
+    const { instances, sliceItems } = createBoxInstances(boxVariants);
+    instances.forEach((instance) => boxComponent.appendChild(instance));
+
+    // save the updated state
+    sliceItems[BoxPropertyName.Radius].forEach((sliceItem) =>
+      radiiMap.set(sliceItem.id, sliceItem)
+    );
+  }
+
+  if (!boxComponent) {
+    restoreBoxComponent(radiiMap, { id: "N", name: "N", refIds: [], value: 0 });
+  }
+};

--- a/widget-src/hooks/useInitTheme.ts
+++ b/widget-src/hooks/useInitTheme.ts
@@ -1,4 +1,8 @@
-import { BoxPropertyName, defaultBoxVariants } from "../_shared/constants";
+import {
+  BoxPropertyName,
+  ComponentNames,
+  defaultBoxVariants,
+} from "../_shared/constants";
 import { SliceItem } from "../_shared/types";
 import { createBoxInstances } from "../_shared/utils/createBoxInstances";
 import { getCurrentBoxVariants } from "../_shared/utils/getCurrentBoxVariants";
@@ -13,7 +17,8 @@ const { useEffect } = widget;
 export const useInitTheme = (radiiMap: SyncedMap<SliceItem>) => {
   useEffect(() => {
     const boxComponent = figma.root.findOne(
-      (node) => node.type === "COMPONENT_SET" && node.name === "BOX"
+      (node) =>
+        node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
     );
 
     if (radiiMap.size !== 0) {
@@ -29,7 +34,7 @@ export const useInitTheme = (radiiMap: SyncedMap<SliceItem>) => {
 
       radiiSliceItems = sliceItems[BoxPropertyName.Radius];
       const box = figma.combineAsVariants(instances, figma.currentPage);
-      box.name = "BOX";
+      box.name = ComponentNames.Box;
     }
 
     if (boxComponent && boxComponent.type === "COMPONENT_SET") {


### PR DESCRIPTION
# Proposed changes

- added a restoreBoxComponent function which create a new BOX component and override the state using new instances created (necessary since the existing state still contains broken refIds)
- function mentioned above is triggered when the user add/edit/delete a slice and the Box component is not found
- Moved edit/delete slices function to separate files
- added some tests to cover as much as possible

closes #6

## Types of changes

- [ ] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [x] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Chore / Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] :scissors: I have ensured that the PR is concise and broken down if needed
- [x] 👀 I have read the [README](../README.md) doc
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
