### PR TITLE
feat(core): add border width slice support

### DIFF
--- a/widget-src/components/BorderWidths/BorderWidthSlice.tsx
+++ b/widget-src/components/BorderWidths/BorderWidthSlice.tsx
@@ -6,16 +6,16 @@ import { editSliceValue } from "../../utils/editSliceValue";
 import { DeleteButton } from "../Buttons/DeleteButton";
 
 const { widget } = figma;
-const { Frame, Rectangle, Input, AutoLayout } = widget;
+const { Frame, Line, Input, AutoLayout } = widget;
 
 interface Props extends SliceItem {
   store: Store;
 }
 
-export const RadiiSlice = ({ store, ...slice }: Props) => {
+export const BorderWidthSlice = ({ store, ...slice }: Props) => {
   return (
     <AutoLayout
-      name="Radius Slice"
+      name="Border width Slice"
       strokeWidth={0}
       overflow="visible"
       direction="horizontal"
@@ -24,16 +24,29 @@ export const RadiiSlice = ({ store, ...slice }: Props) => {
       key={slice.id}
     >
       <Frame width={41} height={41}>
-        <Rectangle
-          name="Slice preview"
-          fill="#D9D9D9"
-          cornerRadius={{ topRight: slice.value }}
-          width={41}
-          height={41}
-        />
+        <Frame name="Frame3" overflow="visible" width={41} height={41}>
+          <Line
+            name="Rectangle 19"
+            y={20.5 + slice.value / 2}
+            stroke="#000"
+            strokeWidth={slice.value}
+            length={16 + slice.value}
+            strokeCap="round"
+          />
+          <Line
+            name="Rectangle 19"
+            y={20.5 + slice.value / 2}
+            stroke="#000"
+            strokeWidth={slice.value}
+            strokeDashPattern={[1, 5 + slice.value]}
+            length={14}
+            x={20 + slice.value}
+            strokeCap="round"
+          />
+        </Frame>
         <DeleteButton
           onClick={() =>
-            deleteSlice({ id: slice.id, sliceName: Slice.Radii, store })
+            deleteSlice({ id: slice.id, sliceName: Slice.BorderWidths, store })
           }
         />
       </Frame>
@@ -53,15 +66,15 @@ export const RadiiSlice = ({ store, ...slice }: Props) => {
             editSliceName({
               event,
               slice,
-              propertyName: BoxPropertyName.Radius,
-              sliceName: Slice.Radii,
+              propertyName: BoxPropertyName.BorderWidth,
+              sliceName: Slice.BorderWidths,
               store,
             })
           }
         />
         <Input
           width="fill-parent"
-          name="Radius value"
+          name="Border width value"
           x={48}
           y={21}
           fill="#000"
@@ -73,10 +86,10 @@ export const RadiiSlice = ({ store, ...slice }: Props) => {
           onTextEditEnd={(event) =>
             editSliceValue({
               event,
-              sliceName: Slice.Radii,
-              store,
+              sliceName: Slice.BorderWidths,
               slice,
-              styleKey: "cornerRadius",
+              styleKey: "strokeWeight",
+              store,
             })
           }
         />

--- a/widget-src/components/BorderWidths/BorderWidthSlices.tsx
+++ b/widget-src/components/BorderWidths/BorderWidthSlices.tsx
@@ -1,8 +1,6 @@
 import { Slice, Store } from "../../types";
 import { AddButton } from "../Buttons/AddButton";
-import { RadiiSlice } from "./RadiiSlice";
-import { addRadiiSlice } from "./utils";
-
+import { BorderWidthSlice } from "./BorderWidthSlice";
 const { widget } = figma;
 const { Text, AutoLayout } = widget;
 
@@ -10,10 +8,10 @@ type Props = {
   store: Store;
 };
 
-export const RadiiSlices = ({ store }: Props) => {
+export const BorderWidthSlices = ({ store }: Props) => {
   return (
     <AutoLayout
-      name="Radii frame"
+      name="Border width frame"
       strokeWidth={0}
       overflow="visible"
       direction="vertical"
@@ -29,16 +27,16 @@ export const RadiiSlices = ({ store }: Props) => {
         height={35}
       >
         <Text
-          name="Radii"
+          name="Border widths"
           fill="#000"
           fontFamily="Inter"
           fontSize={28.63157844543457}
           fontWeight={500}
           strokeWidth={1.789}
         >
-          Radii
+          Border widths
         </Text>
-        <AddButton onClick={() => addRadiiSlice(store)} />
+        <AddButton onClick={() => {}} />
       </AutoLayout>
       <AutoLayout
         name="Frame 2"
@@ -48,8 +46,8 @@ export const RadiiSlices = ({ store }: Props) => {
         direction="horizontal"
         verticalAlignItems="center"
       >
-        {store[Slice.Radii].values().map((radius) => (
-          <RadiiSlice {...radius} store={store} />
+        {store[Slice.BorderWidths].values().map((borderWidth) => (
+          <BorderWidthSlice {...borderWidth} store={store} />
         ))}
       </AutoLayout>
     </AutoLayout>

--- a/widget-src/components/BorderWidths/BorderWidthSlices.tsx
+++ b/widget-src/components/BorderWidths/BorderWidthSlices.tsx
@@ -1,6 +1,7 @@
 import { Slice, Store } from "../../types";
 import { AddButton } from "../Buttons/AddButton";
 import { BorderWidthSlice } from "./BorderWidthSlice";
+import { addBorderWidthSlice } from "./utils";
 const { widget } = figma;
 const { Text, AutoLayout } = widget;
 
@@ -36,7 +37,7 @@ export const BorderWidthSlices = ({ store }: Props) => {
         >
           Border widths
         </Text>
-        <AddButton onClick={() => {}} />
+        <AddButton onClick={() => addBorderWidthSlice(store)} />
       </AutoLayout>
       <AutoLayout
         name="Frame 2"

--- a/widget-src/components/BorderWidths/utils.test.ts
+++ b/widget-src/components/BorderWidths/utils.test.ts
@@ -1,0 +1,110 @@
+import { ComponentNames } from "../../constants";
+import { mockSyncedMap } from "../../test-utils/mockSyncedMap";
+import { Slice, SliceItem } from "../../types";
+import * as UpdateRefIds from "../../utils/updateRefIds";
+import { addBorderWidthSlice } from "./utils";
+
+describe("addRadiiSlice", () => {
+  it("should add new sliceItems on the state and append new instances to the box", () => {
+    const mockAppendChild = jest.fn();
+    jest.spyOn(figma.root, "findOne").mockReturnValue({
+      type: "COMPONENT_SET",
+      name: ComponentNames.Box,
+      appendChild: mockAppendChild,
+    } as any);
+    const spyUpdateRefIds = jest.spyOn(UpdateRefIds, "updateRefIds");
+
+    const mockBorderWidthsMap = mockSyncedMap({
+      "1": { id: "1", name: "S", refIds: [], value: 1 },
+    });
+    const mockRadiiMap = mockSyncedMap({
+      "1": { id: "1", name: "A", refIds: [], value: 3 },
+      "2": { id: "2", name: "B", refIds: [], value: 6 },
+    });
+
+    addBorderWidthSlice({
+      [Slice.BorderWidths]: mockBorderWidthsMap,
+      [Slice.Radii]: mockRadiiMap,
+    });
+
+    expect(mockBorderWidthsMap.set).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "N",
+      value: 0,
+      refIds: expect.any(Array),
+    } as SliceItem);
+    expect(mockBorderWidthsMap.set).toBeCalledTimes(1);
+
+    expect(mockAppendChild).toBeCalledWith(
+      expect.objectContaining({
+        name: "Border width=N, Radius=A",
+        cornerRadius: 3,
+        strokeWeight: 0,
+      })
+    );
+    expect(mockAppendChild).toBeCalledWith(
+      expect.objectContaining({
+        name: "Border width=N, Radius=B",
+        cornerRadius: 6,
+        strokeWeight: 0,
+      })
+    );
+    expect(mockAppendChild).toBeCalledTimes(2);
+
+    expect(spyUpdateRefIds).toBeCalledWith({
+      newSliceItems: [
+        {
+          id: expect.any(String),
+          name: "A",
+          refIds: [expect.any(String)],
+          value: 3,
+        },
+        {
+          id: expect.any(String),
+          name: "B",
+          refIds: [expect.any(String)],
+          value: 6,
+        },
+      ],
+      stateMap: expect.any(Object),
+    });
+  });
+
+  it("should create a new box component and restore the state with the new instances if BOX is not found", () => {
+    const mockAppendChild = jest.fn();
+    const spyUpdateRefIds = jest.spyOn(UpdateRefIds, "updateRefIds");
+    jest.spyOn(figma.root, "findOne").mockReturnValue(null);
+    const mockBorderWidthsMap = mockSyncedMap({
+      "1": { id: "1", name: "S", refIds: ["abc"], value: 1 },
+    });
+    const mockRadiiMap = mockSyncedMap({
+      "1": { id: "1", name: "A", refIds: [], value: 3 },
+      "2": { id: "2", name: "B", refIds: [], value: 6 },
+    });
+
+    addBorderWidthSlice({
+      [Slice.Radii]: mockRadiiMap,
+      [Slice.BorderWidths]: mockBorderWidthsMap,
+    });
+
+    expect(mockAppendChild).not.toBeCalled();
+    expect(figma.combineAsVariants).toBeCalledTimes(1);
+    expect(spyUpdateRefIds).not.toBeCalled();
+
+    // reset state
+    expect(mockBorderWidthsMap.delete).toBeCalledTimes(2);
+    // set up new state (updated sliceItems + new one)
+    expect(mockBorderWidthsMap.set).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "N",
+      value: 0,
+      refIds: expect.any(Array),
+    } as SliceItem);
+    expect(mockBorderWidthsMap.set).toBeCalledWith(expect.any(String), {
+      id: expect.any(String),
+      name: "S",
+      value: 1,
+      refIds: expect.any(Array),
+    } as SliceItem);
+  });
+});

--- a/widget-src/components/BorderWidths/utils.ts
+++ b/widget-src/components/BorderWidths/utils.ts
@@ -1,0 +1,42 @@
+import { BoxPropertyName, ComponentNames } from "../../constants";
+import { Slice, Store } from "../../types";
+import { createBoxInstances } from "../../utils/createBoxInstances";
+import { getBoxVariantsFromState } from "../../utils/getBoxVariantsFromState";
+import { getVariantCombinations } from "../../utils/getVariantCombinations";
+import { restoreBoxComponent } from "../../utils/restoreBoxComponent";
+import { updateRefIds } from "../../utils/updateRefIds";
+
+export const addBorderWidthSlice = (store: Store) => {
+  const { [Slice.Radii]: radiiMap, [Slice.BorderWidths]: borderWidthsMap } =
+    store;
+  const boxComponent = figma.root.findOne(
+    (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
+  );
+  if (boxComponent?.type === "COMPONENT_SET") {
+    const boxVariants = getVariantCombinations([
+      { propertyName: BoxPropertyName.BorderWidth, variants: { N: 0 } },
+      {
+        propertyName: BoxPropertyName.Radius,
+        variants: getBoxVariantsFromState(radiiMap.values()),
+      },
+    ]);
+    const { instances, sliceItems } = createBoxInstances(boxVariants);
+    instances.forEach((instance) => boxComponent.appendChild(instance));
+
+    // save the updated state
+    sliceItems[BoxPropertyName.BorderWidth].forEach((sliceItem) =>
+      borderWidthsMap.set(sliceItem.id, sliceItem)
+    );
+
+    const newRadiiSliceItems = sliceItems[BoxPropertyName.Radius];
+    updateRefIds({
+      newSliceItems: newRadiiSliceItems,
+      stateMap: radiiMap,
+    });
+  }
+
+  if (!boxComponent) {
+    borderWidthsMap.set("N", { id: "N", name: "N", refIds: [], value: 0 });
+    restoreBoxComponent(store);
+  }
+};

--- a/widget-src/components/Buttons/AddButton.tsx
+++ b/widget-src/components/Buttons/AddButton.tsx
@@ -9,8 +9,6 @@ export const AddButton = ({ onClick }: Props) => {
   return (
     <Frame
       name="Add button"
-      x={82}
-      y={10}
       strokeWidth={0}
       overflow="visible"
       width={20}

--- a/widget-src/components/Buttons/DeleteButton.tsx
+++ b/widget-src/components/Buttons/DeleteButton.tsx
@@ -9,6 +9,11 @@ export function DeleteButton(props: { onClick: () => void }) {
       name="DeleteButton"
       opacity={0}
       hoverStyle={{ opacity: 1 }}
+      fill={{
+        type: "solid",
+        color: { r: 0.5, g: 0.5, b: 0.5, a: 1 },
+        visible: true,
+      }}
       tooltip="Delete this variant and all related component instances"
       {...props}
     >

--- a/widget-src/components/Radii/utils.test.ts
+++ b/widget-src/components/Radii/utils.test.ts
@@ -1,61 +1,110 @@
 import { ComponentNames } from "../../constants";
-import { SliceItem } from "../../types";
+import { mockSyncedMap } from "../../test-utils/mockSyncedMap";
+import { Slice, SliceItem } from "../../types";
+import * as UpdateRefIds from "../../utils/updateRefIds";
 import { addRadiiSlice } from "./utils";
 
 describe("addRadiiSlice", () => {
   it("should add new sliceItems on the state and append new instances to the box", () => {
-    const mockSet = jest.fn();
     const mockAppendChild = jest.fn();
     jest.spyOn(figma.root, "findOne").mockReturnValue({
       type: "COMPONENT_SET",
       name: ComponentNames.Box,
       appendChild: mockAppendChild,
     } as any);
-    addRadiiSlice({ set: mockSet } as unknown as SyncedMap<SliceItem>);
+    const spyUpdateRefIds = jest.spyOn(UpdateRefIds, "updateRefIds");
 
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    const mockRadiiMap = mockSyncedMap({
+      "1": { id: "1", name: "S", refIds: [], value: 1 },
+    });
+    const mockBorderWidthsMap = mockSyncedMap({
+      "1": { id: "1", name: "A", refIds: [], value: 3 },
+      "2": { id: "2", name: "B", refIds: [], value: 6 },
+    });
+
+    addRadiiSlice({
+      [Slice.Radii]: mockRadiiMap,
+      [Slice.BorderWidths]: mockBorderWidthsMap,
+    });
+
+    expect(mockRadiiMap.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "N",
       value: 0,
-      refIds: [expect.any(String)],
+      refIds: expect.any(Array),
     } as SliceItem);
-    expect(mockSet).toBeCalledTimes(1);
+    expect(mockRadiiMap.set).toBeCalledTimes(1);
 
     expect(mockAppendChild).toBeCalledWith(
-      expect.objectContaining({ name: "Radius=N", cornerRadius: 0 })
+      expect.objectContaining({
+        name: "Radius=N, Border width=A",
+        cornerRadius: 0,
+        strokeWeight: 3,
+      })
     );
-    expect(mockAppendChild).toBeCalledTimes(1);
+    expect(mockAppendChild).toBeCalledWith(
+      expect.objectContaining({
+        name: "Radius=N, Border width=B",
+        cornerRadius: 0,
+        strokeWeight: 6,
+      })
+    );
+    expect(mockAppendChild).toBeCalledTimes(2);
+
+    expect(spyUpdateRefIds).toBeCalledWith({
+      newSliceItems: [
+        {
+          id: expect.any(String),
+          name: "A",
+          refIds: [expect.any(String)],
+          value: 3,
+        },
+        {
+          id: expect.any(String),
+          name: "B",
+          refIds: [expect.any(String)],
+          value: 6,
+        },
+      ],
+      stateMap: expect.any(Object),
+    });
   });
 
   it("should create a new box component and restore the state with the new instances if BOX is not found", () => {
-    const mockSet = jest.fn();
     const mockAppendChild = jest.fn();
-    const mockMapDelete = jest.fn();
+    const spyUpdateRefIds = jest.spyOn(UpdateRefIds, "updateRefIds");
     jest.spyOn(figma.root, "findOne").mockReturnValue(null);
+    const mockRadiiMap = mockSyncedMap({
+      "1": { id: "1", name: "S", refIds: ["abc"], value: 1 },
+    });
+    const mockBorderWidthsMap = mockSyncedMap({
+      "1": { id: "1", name: "A", refIds: [], value: 3 },
+      "2": { id: "2", name: "B", refIds: [], value: 6 },
+    });
+
     addRadiiSlice({
-      set: mockSet,
-      values: () => [{ id: "1", name: "S", refIds: ["222"], value: 1 }],
-      keys: () => ["1"],
-      delete: mockMapDelete,
-    } as unknown as SyncedMap<SliceItem>);
+      [Slice.Radii]: mockRadiiMap,
+      [Slice.BorderWidths]: mockBorderWidthsMap,
+    });
 
     expect(mockAppendChild).not.toBeCalled();
     expect(figma.combineAsVariants).toBeCalledTimes(1);
+    expect(spyUpdateRefIds).not.toBeCalled();
 
     // reset state
-    expect(mockMapDelete).toBeCalledTimes(1);
+    expect(mockRadiiMap.delete).toBeCalledTimes(2);
     // set up new state (updated sliceItems + new one)
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockRadiiMap.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "N",
       value: 0,
-      refIds: [expect.any(String)],
+      refIds: expect.any(Array),
     } as SliceItem);
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockRadiiMap.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "S",
       value: 1,
-      refIds: [expect.any(String)],
+      refIds: expect.any(Array),
     } as SliceItem);
   });
 });

--- a/widget-src/components/Radii/utils.ts
+++ b/widget-src/components/Radii/utils.ts
@@ -1,16 +1,24 @@
 import { BoxPropertyName, ComponentNames } from "../../constants";
-import { SliceItem } from "../../types";
+import { Slice, Store } from "../../types";
 import { createBoxInstances } from "../../utils/createBoxInstances";
+import { getBoxVariantsFromState } from "../../utils/getBoxVariantsFromState";
 import { getVariantCombinations } from "../../utils/getVariantCombinations";
 import { restoreBoxComponent } from "../../utils/restoreBoxComponent";
+import { updateRefIds } from "../../utils/updateRefIds";
 
-export const addRadiiSlice = (radiiMap: SyncedMap<SliceItem>) => {
+export const addRadiiSlice = (store: Store) => {
+  const { [Slice.Radii]: radiiMap, [Slice.BorderWidths]: borderWidthsMap } =
+    store;
   const boxComponent = figma.root.findOne(
     (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
   );
   if (boxComponent?.type === "COMPONENT_SET") {
     const boxVariants = getVariantCombinations([
       { propertyName: BoxPropertyName.Radius, variants: { N: 0 } },
+      {
+        propertyName: BoxPropertyName.BorderWidth,
+        variants: getBoxVariantsFromState(borderWidthsMap.values()),
+      },
     ]);
     const { instances, sliceItems } = createBoxInstances(boxVariants);
     instances.forEach((instance) => boxComponent.appendChild(instance));
@@ -19,9 +27,16 @@ export const addRadiiSlice = (radiiMap: SyncedMap<SliceItem>) => {
     sliceItems[BoxPropertyName.Radius].forEach((sliceItem) =>
       radiiMap.set(sliceItem.id, sliceItem)
     );
+
+    const newBorderWidthsSliceItems = sliceItems[BoxPropertyName.BorderWidth];
+    updateRefIds({
+      newSliceItems: newBorderWidthsSliceItems,
+      stateMap: borderWidthsMap,
+    });
   }
 
   if (!boxComponent) {
-    restoreBoxComponent(radiiMap, { id: "N", name: "N", refIds: [], value: 0 });
+    radiiMap.set("N", { id: "N", name: "N", refIds: [], value: 0 });
+    restoreBoxComponent(store);
   }
 };

--- a/widget-src/constants.ts
+++ b/widget-src/constants.ts
@@ -16,6 +16,10 @@ export const defaultBoxVariants: GetVariantsParams = [
     propertyName: BoxPropertyName.Radius,
     variants: { none: 0, XS: 1, L: 10 },
   },
+  {
+    propertyName: BoxPropertyName.BorderWidth,
+    variants: { XS: 2, L: 3, M: 5 },
+  },
 ];
 
 export enum ComponentNames {

--- a/widget-src/hooks/useInitTheme.test.ts
+++ b/widget-src/hooks/useInitTheme.test.ts
@@ -1,25 +1,30 @@
+import { mockSyncedMap } from "../test-utils/mockSyncedMap";
+import { Slice } from "../types";
 import { useInitTheme } from "./useInitTheme";
 
 describe("useInitTheme", () => {
   it("should init the theme with default and create BOX if the state is empty and BOX does not exist", () => {
     jest.spyOn(figma.root, "findOne").mockReturnValue(null);
-    const mockSet = jest.fn();
-    useInitTheme({ size: 0, set: mockSet } as unknown as SyncedMap);
+    const mockState = mockSyncedMap();
+    useInitTheme({
+      [Slice.Radii]: mockState,
+      [Slice.BorderWidths]: mockState,
+    });
 
     expect(figma.combineAsVariants).toBeCalled();
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockState.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "none",
       value: 0,
       refIds: expect.any(Array),
     });
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockState.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "XS",
       value: 1,
       refIds: expect.any(Array),
     });
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockState.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "L",
       value: 10,
@@ -31,10 +36,15 @@ describe("useInitTheme", () => {
     jest
       .spyOn(figma.root, "findOne")
       .mockReturnValue({ type: "COMPONENT_SET" } as any);
-    const mockSet = jest.fn();
-    useInitTheme({ size: 1, set: mockSet } as unknown as SyncedMap);
+    const mockState = mockSyncedMap({
+      anyId: { id: "anyId", name: "A", refIds: [], value: 1 },
+    });
+    useInitTheme({
+      [Slice.Radii]: mockState,
+      [Slice.BorderWidths]: mockState,
+    });
     expect(figma.combineAsVariants).not.toBeCalled();
-    expect(mockSet).not.toBeCalled();
+    expect(mockState.set).not.toBeCalled();
   });
 
   it("should not create the BOX component and should set the state (with current box variants) if the state is empty and the component exist", () => {
@@ -45,18 +55,20 @@ describe("useInitTheme", () => {
         { id: "2", name: "Radius=B", cornerRadius: 20, type: "COMPONENT" },
       ],
     } as unknown as ComponentSetNode);
-    const mockSet = jest.fn();
-
-    useInitTheme({ size: 0, set: mockSet } as unknown as SyncedMap);
+    const mockState = mockSyncedMap();
+    useInitTheme({
+      [Slice.Radii]: mockState,
+      [Slice.BorderWidths]: mockState,
+    });
 
     expect(figma.combineAsVariants).not.toBeCalled();
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockState.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "A",
       value: 10,
       refIds: ["1"],
     });
-    expect(mockSet).toBeCalledWith(expect.any(String), {
+    expect(mockState.set).toBeCalledWith(expect.any(String), {
       id: expect.any(String),
       name: "B",
       value: 20,

--- a/widget-src/hooks/useInitTheme.ts
+++ b/widget-src/hooks/useInitTheme.ts
@@ -3,18 +3,18 @@ import {
   defaultBoxVariants,
   BoxPropertyName,
 } from "../constants";
-import { SliceItem } from "../types";
+import { Slice, SliceItem, Store } from "../types";
 import { createBoxInstances } from "../utils/createBoxInstances";
 import { getCurrentBoxVariants } from "../utils/getCurrentBoxVariants";
-import {
-  GetVariantsParams,
-  getVariantCombinations,
-} from "../utils/getVariantCombinations";
+import { getVariantCombinations } from "../utils/getVariantCombinations";
 
 const { widget } = figma;
 const { useEffect } = widget;
 
-export const useInitTheme = (radiiMap: SyncedMap<SliceItem>) => {
+export const useInitTheme = ({
+  [Slice.Radii]: radiiMap,
+  [Slice.BorderWidths]: borderWidthsMap,
+}: Store) => {
   useEffect(() => {
     const boxComponent = figma.root.findOne(
       (node) =>
@@ -25,14 +25,15 @@ export const useInitTheme = (radiiMap: SyncedMap<SliceItem>) => {
       return;
     }
 
-    let getVariantsParams: GetVariantsParams = defaultBoxVariants;
     let radiiSliceItems: SliceItem[] = [];
+    let borderWidthsSliceItems: SliceItem[] = [];
 
     if (!boxComponent) {
-      const boxVariants = getVariantCombinations(getVariantsParams);
+      const boxVariants = getVariantCombinations(defaultBoxVariants);
       const { instances, sliceItems } = createBoxInstances(boxVariants);
 
       radiiSliceItems = sliceItems[BoxPropertyName.Radius];
+      borderWidthsSliceItems = sliceItems[BoxPropertyName.BorderWidth];
       const box = figma.combineAsVariants(instances, figma.currentPage);
       box.name = ComponentNames.Box;
     }
@@ -40,10 +41,15 @@ export const useInitTheme = (radiiMap: SyncedMap<SliceItem>) => {
     if (boxComponent && boxComponent.type === "COMPONENT_SET") {
       const currentVariants = getCurrentBoxVariants(boxComponent.children);
       radiiSliceItems = currentVariants[BoxPropertyName.Radius];
+      borderWidthsSliceItems = currentVariants[BoxPropertyName.BorderWidth];
     }
 
     radiiSliceItems.forEach((sliceItem) => {
       radiiMap.set(sliceItem.id, sliceItem);
+    });
+
+    borderWidthsSliceItems.forEach((sliceItem) => {
+      borderWidthsMap.set(sliceItem.id, sliceItem);
     });
   });
 };

--- a/widget-src/test-utils/mockSyncedMap.ts
+++ b/widget-src/test-utils/mockSyncedMap.ts
@@ -1,0 +1,27 @@
+import { SliceItem } from "../types";
+
+export const mockSyncedMap = (initialValues?: Record<string, SliceItem>) => {
+  const map: Record<string, SliceItem> = { ...initialValues };
+
+  const mockSet = jest.fn(
+    (key: string, value: SliceItem) => (map[key] = value)
+  );
+  const mockGet = jest.fn((key: string) => map[key]);
+  const mockHas = jest.fn();
+  const mockDelete = jest.fn((key: string) => delete map[key]);
+  const mockKeys = jest.fn(() => Object.keys(map));
+  const mockValues = jest.fn(() => Object.values(map));
+  const mockEntries = jest.fn(() => Object.entries(map));
+
+  return {
+    delete: mockDelete,
+    entries: mockEntries,
+    get: mockGet,
+    set: mockSet,
+    has: mockHas,
+    keys: mockKeys,
+    values: mockValues,
+    length: Object.keys(map).length,
+    size: Object.keys(map).length,
+  } as unknown as SyncedMap<SliceItem>;
+};

--- a/widget-src/types.ts
+++ b/widget-src/types.ts
@@ -17,3 +17,10 @@ export type BoxVariant = {
 } & Record<BoxStyleKeys, number>;
 
 export type BoxSliceItems = Record<BoxPropertyName, SliceItem[]>;
+
+export enum Slice {
+  Radii = "radii",
+  BorderWidths = "border-widths",
+}
+
+export type Store = Record<Slice, SyncedMap<SliceItem>>;

--- a/widget-src/utils/deleteSlice.ts
+++ b/widget-src/utils/deleteSlice.ts
@@ -1,9 +1,15 @@
 import { ComponentNames } from "../constants";
-import { SliceItem } from "../types";
+import { Slice, Store } from "../types";
 import { restoreBoxComponent } from "./restoreBoxComponent";
 
-export const deleteSlice = (id: string, map: SyncedMap<SliceItem>) => {
-  if (map.size < 1) {
+export const deleteSlice = (params: {
+  id: string;
+  store: Store;
+  sliceName: Slice;
+}) => {
+  const { id, sliceName, store } = params;
+  const stateMap = store[sliceName];
+  if (stateMap.size < 1) {
     figma.notify("Impossible to remove all slices. Please keep at least one", {
       error: true,
       timeout: 3000,
@@ -15,15 +21,17 @@ export const deleteSlice = (id: string, map: SyncedMap<SliceItem>) => {
     (node) => node.type === "COMPONENT_SET" && node.name === ComponentNames.Box
   );
 
-  const refIds = map.get(id)?.refIds || [];
-  map.delete(id);
+  const refIds = stateMap.get(id)?.refIds;
+  stateMap.delete(id);
 
-  if (boxComponent) {
+  if (boxComponent && refIds) {
     refIds.map((refId) => {
       figma.getNodeById(refId)?.remove();
     });
     return;
   }
 
-  restoreBoxComponent(map);
+  if (!boxComponent) {
+    restoreBoxComponent(store);
+  }
 };

--- a/widget-src/utils/editSliceName.test.ts
+++ b/widget-src/utils/editSliceName.test.ts
@@ -2,8 +2,9 @@ import { BoxPropertyName } from "../constants";
 import { editSliceName } from "./editSliceName";
 import * as Utils from "./utils";
 import * as RestoreBoxComponent from "./restoreBoxComponent";
+import { Slice, Store } from "../types";
+import { mockSyncedMap } from "../test-utils/mockSyncedMap";
 
-const mockSet = jest.fn();
 const mockRestoreBoxComponent = jest.fn();
 jest
   .spyOn(RestoreBoxComponent, "restoreBoxComponent")
@@ -19,19 +20,26 @@ describe("editSliceName", () => {
     jest
       .spyOn(Utils, "updateVariantName")
       .mockImplementation(mockUpdateVariantName);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceName({
-      e: { characters: "newName" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "newName" },
       slice: {
         id: "1",
         name: "oldName",
         refIds: ["instance1", "instance2"],
         value: 1,
       },
+      propertyName: BoxPropertyName.Radius,
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "newName",
       refIds: ["instance1", "instance2"],
@@ -54,19 +62,26 @@ describe("editSliceName", () => {
     jest
       .spyOn(Utils, "updateVariantName")
       .mockImplementation(mockUpdateVariantName);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceName({
-      e: { characters: "" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "" },
       slice: {
         id: "1",
         name: "oldName",
         refIds: ["instance1", "instance2"],
         value: 1,
       },
+      propertyName: BoxPropertyName.Radius,
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "oldName",
       refIds: ["instance1", "instance2"],
@@ -87,19 +102,26 @@ describe("editSliceName", () => {
     jest
       .spyOn(Utils, "updateVariantName")
       .mockImplementation(mockUpdateVariantName);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceName({
-      e: { characters: "" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "" },
       slice: {
         id: "1",
         name: "oldName",
         refIds: ["instance1", "instance2"],
         value: 1,
       },
+      propertyName: BoxPropertyName.Radius,
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "oldName",
       refIds: ["instance1", "instance2"],
@@ -115,19 +137,26 @@ describe("editSliceName", () => {
     jest
       .spyOn(Utils, "updateVariantName")
       .mockImplementation(mockUpdateVariantName);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceName({
-      e: { characters: "" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "" },
       slice: {
         id: "1",
         name: "oldName",
         refIds: ["instance1", "instance2"],
         value: 1,
       },
+      propertyName: BoxPropertyName.Radius,
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "oldName",
       refIds: ["instance1", "instance2"],

--- a/widget-src/utils/editSliceName.ts
+++ b/widget-src/utils/editSliceName.ts
@@ -1,16 +1,18 @@
 import { ComponentNames, BoxPropertyName } from "../constants";
-import { SliceItem } from "../types";
+import { Slice, SliceItem, Store } from "../types";
 import { restoreBoxComponent } from "./restoreBoxComponent";
 import { updateVariantName } from "./utils";
 
 export const editSliceName = (params: {
   slice: SliceItem;
-  e: TextEditEvent;
-  map: SyncedMap<SliceItem>;
+  event: TextEditEvent;
+  propertyName: BoxPropertyName;
+  store: Store;
+  sliceName: Slice;
 }) => {
-  const { e, map, slice } = params;
-  const newName = e.characters || slice.name;
-  map.set(slice.id, {
+  const { event, slice, propertyName, sliceName, store } = params;
+  const newName = event.characters || slice.name;
+  store[sliceName].set(slice.id, {
     ...slice,
     name: newName,
   });
@@ -26,11 +28,11 @@ export const editSliceName = (params: {
         variant.name = updateVariantName({
           instanceName: variant.name,
           newVariantName: newName,
-          propertyName: BoxPropertyName.Radius,
+          propertyName,
         });
       }
     });
     return;
   }
-  restoreBoxComponent(map);
+  restoreBoxComponent(store);
 };

--- a/widget-src/utils/editSliceValue.test.ts
+++ b/widget-src/utils/editSliceValue.test.ts
@@ -1,7 +1,8 @@
+import { mockSyncedMap } from "../test-utils/mockSyncedMap";
+import { Slice, Store } from "../types";
 import { editSliceValue } from "./editSliceValue";
 import * as RestoreBoxComponent from "./restoreBoxComponent";
 
-const mockSet = jest.fn();
 const mockRestoreBoxComponent = jest.fn();
 jest
   .spyOn(RestoreBoxComponent, "restoreBoxComponent")
@@ -15,10 +16,14 @@ describe("editSliceValue", () => {
       name: "name",
       value: 0,
     } as any);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceValue({
-      e: { characters: "1" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "1" },
       slice: {
         id: "1",
         name: "name",
@@ -26,9 +31,11 @@ describe("editSliceValue", () => {
         value: 1,
       },
       styleKey: "cornerRadius",
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "name",
       refIds: ["instance1", "instance2"],
@@ -45,10 +52,14 @@ describe("editSliceValue", () => {
       name: "name",
       value: 1,
     } as any);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceValue({
-      e: { characters: "any non-number string" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "any non-number string" },
       slice: {
         id: "1",
         name: "name",
@@ -56,9 +67,11 @@ describe("editSliceValue", () => {
         value: 1,
       },
       styleKey: "cornerRadius",
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "name",
       refIds: ["instance1", "instance2"],
@@ -75,10 +88,14 @@ describe("editSliceValue", () => {
       name: "name",
       value: 1,
     } as any);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceValue({
-      e: { characters: "2" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "2" },
       slice: {
         id: "1",
         name: "name",
@@ -86,9 +103,11 @@ describe("editSliceValue", () => {
         value: 2,
       },
       styleKey: "cornerRadius",
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "name",
       refIds: ["instance1", "instance2"],
@@ -100,10 +119,14 @@ describe("editSliceValue", () => {
   it("should not crash if getNodeById returns null", () => {
     jest.spyOn(figma.root, "findOne").mockReturnValue({} as any);
     jest.spyOn(figma, "getNodeById").mockReturnValue(null);
+    const stateMap = mockSyncedMap();
+    const store: Store = {
+      [Slice.Radii]: stateMap,
+      [Slice.BorderWidths]: mockSyncedMap(),
+    };
 
     editSliceValue({
-      e: { characters: "2" },
-      map: { set: mockSet } as unknown as SyncedMap,
+      event: { characters: "2" },
       slice: {
         id: "1",
         name: "name",
@@ -111,9 +134,11 @@ describe("editSliceValue", () => {
         value: 2,
       },
       styleKey: "cornerRadius",
+      sliceName: Slice.Radii,
+      store,
     });
 
-    expect(mockSet).toBeCalledWith("1", {
+    expect(stateMap.set).toBeCalledWith("1", {
       id: "1",
       name: "name",
       refIds: ["instance1", "instance2"],

--- a/widget-src/utils/editSliceValue.ts
+++ b/widget-src/utils/editSliceValue.ts
@@ -1,16 +1,17 @@
 import { ComponentNames } from "../constants";
-import { SliceItem, BoxStyleKeys } from "../types";
+import { SliceItem, BoxStyleKeys, Store, Slice } from "../types";
 import { restoreBoxComponent } from "./restoreBoxComponent";
 
 export const editSliceValue = (params: {
   slice: SliceItem;
-  e: TextEditEvent;
-  map: SyncedMap<SliceItem>;
+  event: TextEditEvent;
   styleKey: BoxStyleKeys;
+  store: Store;
+  sliceName: Slice;
 }) => {
-  const { e, map, slice, styleKey } = params;
-  const newValue = Number(e.characters) || slice.value;
-  map.set(slice.id, {
+  const { event, slice, styleKey, store, sliceName } = params;
+  const newValue = Number(event.characters) || slice.value;
+  store[sliceName].set(slice.id, {
     ...slice,
     value: newValue,
   });
@@ -28,5 +29,5 @@ export const editSliceValue = (params: {
     });
     return;
   }
-  restoreBoxComponent(map);
+  restoreBoxComponent(store);
 };

--- a/widget-src/utils/getBoxVariantsFromState.ts
+++ b/widget-src/utils/getBoxVariantsFromState.ts
@@ -1,19 +1,16 @@
-import { BoxPropertyName } from "../constants";
 import { SliceItem } from "../types";
 import { GetVariantsParams } from "./getVariantCombinations";
 
-export const getBoxVariantsFromState = (
-  radiiSliceItems: SliceItem[]
-): GetVariantsParams => {
-  const variants = radiiSliceItems.reduce<GetVariantsParams[0]["variants"]>(
-    (acc, radiiSliceItem) => {
+export const getBoxVariantsFromState = (sliceItems: SliceItem[]) => {
+  const variants = sliceItems.reduce<GetVariantsParams[0]["variants"]>(
+    (acc, sliceItem) => {
       return {
         ...acc,
-        [radiiSliceItem.name]: radiiSliceItem.value,
+        [sliceItem.name]: sliceItem.value,
       };
     },
     {}
   );
 
-  return [{ propertyName: BoxPropertyName.Radius, variants }];
+  return variants;
 };

--- a/widget-src/utils/updateRefIds.test.ts
+++ b/widget-src/utils/updateRefIds.test.ts
@@ -1,0 +1,62 @@
+import { mockSyncedMap } from "../test-utils/mockSyncedMap";
+import { SliceItem } from "../types";
+import { updateRefIds } from "./updateRefIds";
+
+describe("updateRefIds", () => {
+  it("should add refIds saved on newSliceItems to the existing stateMap", () => {
+    const newSliceItems: SliceItem[] = [
+      { id: "anyId", name: "A", refIds: ["newRef1", "newRef2"], value: 0 },
+      { id: "anyId:2", name: "B", refIds: ["newRef3", "newRef4"], value: 1 },
+    ];
+
+    const mockStateMap = mockSyncedMap({
+      "anyId:a": {
+        id: "anyId:a",
+        name: "A",
+        refIds: ["oldRef1", "oldRef2"],
+        value: 0,
+      },
+      "anyId:b": {
+        id: "anyId:b",
+        name: "B",
+        refIds: ["oldRef3", "oldRef4"],
+        value: 1,
+      },
+    });
+
+    updateRefIds({ newSliceItems, stateMap: mockStateMap });
+
+    expect(mockStateMap.set).toBeCalledTimes(2);
+    expect(mockStateMap.set).toBeCalledWith("anyId:a", {
+      id: "anyId:a",
+      name: "A",
+      refIds: ["oldRef1", "oldRef2", "newRef1", "newRef2"],
+      value: 0,
+    });
+    expect(mockStateMap.set).toBeCalledWith("anyId:b", {
+      id: "anyId:b",
+      name: "B",
+      refIds: ["oldRef3", "oldRef4", "newRef3", "newRef4"],
+      value: 1,
+    });
+  });
+  it("should not add anything if the name doesn't match", () => {
+    const newSliceItems: SliceItem[] = [
+      { id: "anyId", name: "A", refIds: ["newRef1", "newRef2"], value: 0 },
+      { id: "anyId:2", name: "B", refIds: ["newRef3", "newRef4"], value: 1 },
+    ];
+
+    const mockStateMap = mockSyncedMap({
+      "anyId:a": {
+        id: "anyId:a",
+        name: "notMatchingName",
+        refIds: ["oldRef1", "oldRef2"],
+        value: 0,
+      },
+    });
+
+    updateRefIds({ newSliceItems, stateMap: mockStateMap });
+
+    expect(mockStateMap.set).not.toBeCalled();
+  });
+});

--- a/widget-src/utils/updateRefIds.ts
+++ b/widget-src/utils/updateRefIds.ts
@@ -1,0 +1,25 @@
+import { SliceItem } from "../types";
+
+type Params = {
+  newSliceItems: SliceItem[];
+  stateMap: SyncedMap<SliceItem>;
+};
+
+/**
+ * It adds the refIds from newSliceItems
+ * to the provided stateMap
+ */
+
+export const updateRefIds = ({ newSliceItems, stateMap }: Params) => {
+  stateMap.values().forEach((sliceItem) => {
+    const newRefs = newSliceItems.find(
+      ({ name }) => name === sliceItem.name
+    )?.refIds;
+    if (newRefs) {
+      stateMap.set(sliceItem.id, {
+        ...sliceItem,
+        refIds: [...sliceItem.refIds, ...newRefs],
+      });
+    }
+  });
+};

--- a/widget-src/widget.tsx
+++ b/widget-src/widget.tsx
@@ -1,14 +1,20 @@
-import { SliceItem } from "./types";
+import { Slice, SliceItem } from "./types";
 import { RadiiSlices } from "./components/Radii/RadiiSlices";
 import { useInitTheme } from "./hooks/useInitTheme";
+import { BorderWidthSlices } from "./components/BorderWidths/BorderWidthSlices";
 
 const { widget } = figma;
 const { useSyncedMap, AutoLayout } = widget;
 
 function Widget() {
-  const radiiMap = useSyncedMap<SliceItem>("radii");
+  const radiiMap = useSyncedMap<SliceItem>(Slice.Radii);
+  const borderWidthsMap = useSyncedMap<SliceItem>(Slice.BorderWidths);
+  const store = {
+    [Slice.Radii]: radiiMap,
+    [Slice.BorderWidths]: borderWidthsMap,
+  };
 
-  useInitTheme(radiiMap);
+  useInitTheme(store);
 
   return (
     <AutoLayout
@@ -24,7 +30,8 @@ function Widget() {
       }}
       verticalAlignItems="center"
     >
-      <RadiiSlices radiiMap={radiiMap} />
+      <RadiiSlices store={store} />
+      <BorderWidthSlices store={store} />
     </AutoLayout>
   );
 }


### PR DESCRIPTION
# Proposed changes

introduced support for border width slice. Did some refactoring and changed some logic to handle the creation of border width-related box instances

closes #11

## Types of changes

- [x] ✨ New feature (non-breaking change which adds functionality or enhancements)
- [ ] 🐛 Bugfix (non-breaking change which fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ✅ Tests (added tests for an existing feature)
- [ ] 📚 Chore / Documentation Update (if none of the other choices apply)
- [ ] 🙌 Other (please, write a clear and concise description of the proposal in the section above)

## Checklist

- [x] :scissors: I have ensured that the PR is concise and broken down if needed
- [x] 👀 I have read the [README](../README.md) doc
- [x] 🧪 I have added tests that prove my fix is effective or that my feature works
- [ ] 📚 I have added necessary documentation (if appropriate)
- [x] 🔀 Any dependent changes have been merged and published in downstream modules
